### PR TITLE
Potential fix for code scanning alert no. 33: Missing rate limiting

### DIFF
--- a/server/routes/contests.js
+++ b/server/routes/contests.js
@@ -12,7 +12,7 @@ const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // limit each IP to 100 requests per windowMs
 });
-router.get("/", async (req, res) => {
+router.get("/", limiter, async (req, res) => {
   try {
     const { platforms, status, lastWeekOnly } = req.query;
     const query = {};
@@ -67,7 +67,7 @@ router.get("/", async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-router.get("/upcoming", async (req, res) => {
+router.get("/upcoming", limiter, async (req, res) => {
   try {
     const { platforms } = req.query;
     const query = { status: "upcoming" };
@@ -83,7 +83,7 @@ router.get("/upcoming", async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-router.get("/ongoing", async (req, res) => {
+router.get("/ongoing", limiter, async (req, res) => {
   try {
     const { platforms } = req.query;
     const query = { status: "ongoing" };
@@ -99,7 +99,7 @@ router.get("/ongoing", async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-router.get("/past", async (req, res) => {
+router.get("/past", limiter, async (req, res) => {
   try {
     const { platforms, limit, lastWeekOnly } = req.query;
     const query = { status: "past" };
@@ -146,7 +146,7 @@ router.get("/past", async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-router.post("/update", async (req, res) => {
+router.post("/update", limiter, async (req, res) => {
   try {
     console.log("Manual contest update triggered");
     const statusUpdates = await updateContestStatus();


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/33](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/33)

To fix the problem, we need to apply rate limiting to the route handlers that perform database access operations. This can be achieved by using the `express-rate-limit` middleware. We will create a rate limiter and apply it to the relevant routes to ensure that the number of requests from a single IP is limited within a specified time window.

1. Import the `express-rate-limit` package.
2. Create a rate limiter with appropriate configuration (e.g., maximum 100 requests per 15 minutes).
3. Apply the rate limiter to the route handlers that perform database access operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
