### PR TITLE
Potential fix for code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/server/routes/reminders.js
+++ b/server/routes/reminders.js
@@ -86,7 +86,8 @@ router.delete("/:reminderId", auth, async (req, res) => {
     });
   } catch (err) {
     console.error(
-      `Error deleting reminder ${req.params.reminderId}:`,
+      "Error deleting reminder %s:",
+      req.params.reminderId,
       err.message
     );
     res.status(500).json({ message: err.message });


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/4](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/4)

To fix the problem, we should ensure that the user-provided value is properly sanitized or included in the log message using a safe method. The best way to fix this is to use a `%s` specifier in the format string and pass the user-provided value as a separate argument to the `console.error` function. This approach ensures that the user-provided value is treated as a string and not as part of the format string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
