### PR TITLE
Potential fix for code scanning alert no. 48: Database query built from user-controlled sources

### DIFF
--- a/server/routes/bookmarks.js
+++ b/server/routes/bookmarks.js
@@ -77,7 +77,10 @@ router.post("/toggle", auth, async (req, res) => {
         .json({ message: "userId and contestId are required" });
     }
     // Ensure the contest exists
-    const contest = await Contest.findById(contestId);
+    if (typeof contestId !== "string") {
+      return res.status(400).json({ message: "Invalid contestId" });
+    }
+    const contest = await Contest.findById({ _id: { $eq: contestId } });
     if (!contest) {
       return res.status(404).json({ message: "Contest not found" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/48](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/48)

To fix the problem, we need to ensure that the `contestId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate the `contestId` to ensure it is a valid string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
