### PR TITLE
Potential fix for code scanning alert no. 46: Database query built from user-controlled sources

### DIFF
--- a/server/routes/bookmarks.js
+++ b/server/routes/bookmarks.js
@@ -44,7 +44,10 @@ router.post("/", auth, limiter, async (req, res) => {
         .json({ message: "userId and contestId are required" });
     }
     // Ensure the contest exists
-    const contest = await Contest.findById(contestId);
+    if (typeof contestId !== "string") {
+      return res.status(400).json({ message: "Invalid contestId" });
+    }
+    const contest = await Contest.findById({ _id: { $eq: contestId } });
     if (!contest) {
       return res.status(404).json({ message: "Contest not found" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/46](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/46)

To fix the problem, we need to ensure that the `contestId` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. Additionally, we should validate that `contestId` is a valid string before using it in the query.

1. Use the `$eq` operator to ensure `contestId` is treated as a literal value.
2. Validate that `contestId` is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
