### PR TITLE
Potential fix for code scanning alert no. 6: Use of externally-controlled format string

### DIFF
--- a/server/routes/contests.js
+++ b/server/routes/contests.js
@@ -244,7 +244,8 @@ router.post("/:id/solution", [limiter, auth, admin], async (req, res) => {
     res.json(contest);
   } catch (err) {
     console.error(
-      `Error updating solution for contest ${req.params.id}:`,
+      "Error updating solution for contest %s:",
+      req.params.id,
       err.message
     );
     res.status(500).json({ message: err.message });


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/6](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/6)

To fix the problem, we should avoid directly embedding the user-provided value in the format string. Instead, we can use a `%s` specifier in the format string and pass the user-provided value as a separate argument. This ensures that the user input is treated as a string and not as a part of the format string.

- Modify the `console.error` statement on line 247 to use a `%s` specifier.
- Pass the `req.params.id` as a separate argument to the `console.error` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
