### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/server/routes/bookmarks.js
+++ b/server/routes/bookmarks.js
@@ -148,7 +148,8 @@ router.delete("/:bookmarkId", auth, limiter, async (req, res) => {
     res.json({ message: "Bookmark deleted successfully" });
   } catch (err) {
     console.error(
-      `Error deleting bookmark ${req.params.bookmarkId}:`,
+      "Error deleting bookmark %s:",
+      req.params.bookmarkId,
       err.message
     );
     res.status(500).json({ message: err.message });


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/3](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/3)

To fix the problem, we should ensure that the user-provided `bookmarkId` is properly sanitized before being included in the format string. The best way to achieve this is to use a `%s` specifier in the format string and pass the `bookmarkId` as a corresponding argument. This approach ensures that the `bookmarkId` is treated as a string and prevents any unintended format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
