### PR TITLE
Potential fix for code scanning alert no. 37: Missing rate limiting

### DIFF
--- a/server/routes/contests.js
+++ b/server/routes/contests.js
@@ -163,7 +163,7 @@ router.post("/update", limiter, async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-router.post("/force-update-past", async (req, res) => {
+router.post("/force-update-past", limiter, async (req, res) => {
   try {
     console.log("Force updating past contests");
     const now = new Date();


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/37](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/37)

To fix the problem, we need to add rate limiting to the route handler on line 166. This can be done by applying the existing `limiter` middleware to this route, similar to how it is applied to other routes in the same file. This will ensure that the route is protected from denial-of-service attacks by limiting the number of requests that can be made in a given time window.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
