### PR TITLE
Potential fix for code scanning alert no. 38: Missing rate limiting

### DIFF
--- a/server/routes/contests.js
+++ b/server/routes/contests.js
@@ -207,7 +207,7 @@ router.post("/force-update-past", limiter, async (req, res) => {
     res.status(500).json({ message: err.message });
   }
 });
-router.get("/:id", async (req, res) => {
+router.get("/:id", limiter, async (req, res) => {
   try {
     const contest = await Contest.findById(req.params.id);
     if (!contest) {


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/38](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/38)

To fix the problem, we need to apply rate limiting to the route handler on line 210. This can be done by using the existing `limiter` middleware that is already defined in the file. We will add the `limiter` middleware to the route handler to ensure that the number of requests to this route is limited, thereby preventing potential denial-of-service attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
