### PR TITLE
Potential fix for code scanning alert no. 61: Missing rate limiting

### DIFF
--- a/server/routes/api/auth.js
+++ b/server/routes/api/auth.js
@@ -12,7 +12,7 @@ const limiter = rateLimit({
   max: 100, // limit each IP to 100 requests per windowMs
 });
 
-router.get("/", auth, limiter, async (req, res) => {
+router.get("/", limiter, auth, async (req, res) => {
   try {
     const user = await User.findById(req.user.id).select("-password");
     res.json(user);


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/61](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/61)

To fix the problem, we need to apply rate limiting to the authorization route. This can be done by using the `express-rate-limit` middleware, which is already imported and configured in the provided code snippet. We will apply the `limiter` middleware to the authorization route to ensure that the number of requests to this endpoint is limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
