### PR TITLE
Potential fix for code scanning alert no. 62: Database query built from user-controlled sources

### DIFF
--- a/server/routes/bookmarks.js
+++ b/server/routes/bookmarks.js
@@ -43,8 +43,8 @@ router.post("/", auth, limiter, async (req, res) => {
     if (!contest) {
       return res.status(404).json({ message: "Contest not found" });
     }
-    if (typeof userId !== "string") {
-      return res.status(400).json({ message: "Invalid userId" });
+    if (typeof userId !== "string" || typeof contestId !== "string") {
+      return res.status(400).json({ message: "Invalid userId or contestId" });
     }
     const existingBookmark = await Bookmark.findOne({
       userId: userId,
@@ -83,8 +83,8 @@ router.post("/toggle", auth, limiter, async (req, res) => {
       return res.status(404).json({ message: "Contest not found" });
     }
     const existingBookmark = await Bookmark.findOne({
-      userId: userId,
-      contestId: contestId,
+      userId: { $eq: userId },
+      contestId: { $eq: contestId },
     });
     if (existingBookmark) {
       await Bookmark.findByIdAndDelete(existingBookmark._id);


### PR DESCRIPTION
Potential fix for [https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/62](https://github.com/ArmaanjeetSandhu/contest-tracker-assignment/security/code-scanning/62)

To fix the issue, we need to ensure that the `userId` and `contestId` values are treated as literal values in the MongoDB query. This can be achieved by using the `$eq` operator in the query object. The `$eq` operator ensures that the values are interpreted as literals and not as query objects, mitigating the risk of NoSQL injection.

Additionally, we should validate that `userId` and `contestId` are strings before using them in the query. This adds an extra layer of protection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
